### PR TITLE
fixed license header for shell runners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
                     </programs>
                     <repositoryName>lib</repositoryName>
                     <repositoryLayout>flat</repositoryLayout>
+                    <licenseHeaderFile>src/main/assembly/header.txt</licenseHeaderFile>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/assembly/header.txt
+++ b/src/main/assembly/header.txt
@@ -1,0 +1,16 @@
+Copyright 2018, COURSE-IT Ltd.
+
+This file is part of 2bass.
+
+2bass is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+2bass is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with 2bass.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Default license header for shell runners is for Apache license,
inserted GPL header instead.