### PR TITLE
update testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <checkstyle.version>8.18</checkstyle.version>
         <junit.version>5.0.0</junit.version>
         <junit.platform.version>1.0.0</junit.platform.version>
-        <testcontainers.version>1.6.0</testcontainers.version>
+        <testcontainers.version>1.10.7</testcontainers.version>
         <!--plugin versions -->
         <javacc.maven.plugin.version>2.6</javacc.maven.plugin.version>
         <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>

--- a/src/test/java/ru/curs/bass/OracleBassTest.java
+++ b/src/test/java/ru/curs/bass/OracleBassTest.java
@@ -13,11 +13,11 @@ public class OracleBassTest extends BassTest {
         Locale.setDefault(Locale.US);
     }
 
-    OracleContainer<?> oracle;
+    OracleContainer oracle;
 
     @BeforeEach
     void beforeEach() throws Exception  {
-        oracle = new OracleContainer<>();
+        oracle = new OracleContainer();
         oracle.start();
         super.beforeEach();
     }

--- a/src/test/resources/container-license-acceptance.txt
+++ b/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2017-CU12

--- a/src/test/resources/testcontainers.properties
+++ b/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+oracle.container.image=thebookpeople/oracle-xe-11g


### PR DESCRIPTION
The problem: The old version of Testcontainers relies on a removed OracleXE image. Because of this, it's not possible to build 2bass on a fresh environment without having needed image cached.